### PR TITLE
MainActivityとSignInActivity間の遷移

### DIFF
--- a/app/src/main/java/com/techcafe/todone/MainActivity.kt
+++ b/app/src/main/java/com/techcafe/todone/MainActivity.kt
@@ -36,7 +36,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.drawer_menu_settings -> navController.navigate(R.id.settings)
                 R.id.drawer_menu_profile -> navController.navigate(R.id.profile)
                 R.id.drawer_menu_about_app -> navController.navigate(R.id.aboutapp)
-                R.id.drawer_menu_sign_in -> navController.navigate(R.id.sign_in)
+                R.id.drawer_menu_sign_in -> navController.navigate(R.id.action_home_fragment_to_sign_in_graph)
             }
             drawer_layout.closeDrawer(nav_view)
             true

--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/common.gradle')
 dependencies {
     implementation project(':model')
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.2.1'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.2.1'
+    api Dep.AndroidX.Navigation.fragmentKtx
+    api Dep.AndroidX.Navigation.uiKtx
+    api Dep.AndroidX.Navigation.runtimeKtx
 }

--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -6,7 +6,11 @@
     <fragment
         android:id="@+id/home"
         android:name="com.techcafe.todone.home.HomeFragment"
-        android:label="Home" />
+        android:label="Home" >
+        <action
+            android:id="@+id/action_home_fragment_to_sign_in_graph"
+            app:destination="@id/navigation_sign_in" />
+    </fragment>
     <fragment
         android:id="@+id/now"
         android:name="com.techcafe.todone.now.NowFragment"
@@ -31,12 +35,5 @@
         android:id="@+id/aboutapp"
         android:name="com.techcafe.todone.aboutapp.AboutAppFragment"
         android:label="AboutApp" />
-    <activity
-        android:id="@+id/sign_in"
-        android:name="com.techcafe.todone.auth.SignInActivity"
-        android:label="SignIn" />
-    <activity
-        android:id="@+id/main"
-        android:name="com.techcafe.todone.MainActivity"
-        android:label="Main" />
+    <include app:graph="@navigation/navigation_sign_in" />
 </navigation>

--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation_sign_in.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation_sign_in.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navigation_sign_in"
+    app:startDestination="@id/sign_in">
+
+    <fragment
+        android:id="@+id/sign_in"
+        android:name="com.techcafe.todone.auth.signin.SignInFragment"
+        android:label="SignIn" />
+
+</navigation>

--- a/features/auth/build.gradle
+++ b/features/auth/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 
     implementation Dep.Firebase.ui
     implementation Dep.Firebase.auth
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation Dep.AndroidX.appCompat
+    implementation Dep.AndroidX.constraint
 }

--- a/features/auth/src/main/java/com/techcafe/todone/auth/SignInActivity.kt
+++ b/features/auth/src/main/java/com/techcafe/todone/auth/SignInActivity.kt
@@ -1,22 +1,11 @@
 package com.techcafe.todone.auth
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.firebase.ui.auth.AuthUI
-import com.firebase.ui.auth.ErrorCodes
-import com.firebase.ui.auth.IdpResponse
-import com.google.firebase.auth.FirebaseAuth
 import com.techcafe.todone.auth.databinding.ActivitySignInBinding
 
 class SignInActivity : AppCompatActivity() {
-
-    companion object {
-        private const val RC_SIGN_IN = 0
-    }
 
     private lateinit var binding: ActivitySignInBinding
 
@@ -24,37 +13,6 @@ class SignInActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_sign_in)
-        val user = FirebaseAuth.getInstance().currentUser
-        if (user != null) {
-            // TODO MainActivityへ遷移
-            binding.textView.text = user.displayName
-        } else {
-            val configs = arrayListOf(
-                AuthUI.IdpConfig.EmailBuilder().build()
-            )
-            val authIntent = AuthUI.getInstance()
-                .createSignInIntentBuilder()
-                .setAvailableProviders(configs)
-                .build()
-            startActivityForResult(authIntent, RC_SIGN_IN)
-        }
-    }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode != RC_SIGN_IN) return
-        val response = IdpResponse.fromResultIntent(data)
-        if (resultCode == Activity.RESULT_OK) {
-            // TODO MainActivityへ遷移
-            Toast.makeText(this, "Signed in!", Toast.LENGTH_LONG).show()
-            binding.textView.text = "Signed in with " + response?.email
-        } else {
-            val errorMessage = when {
-                response == null -> R.string.sign_in_cancelled
-                response.error?.errorCode == ErrorCodes.NO_NETWORK -> R.string.network_error
-                else -> R.string.unknown_error
-            }
-            Toast.makeText(this, getString(errorMessage), Toast.LENGTH_LONG).show()
-        }
     }
 }

--- a/features/auth/src/main/java/com/techcafe/todone/auth/SignInActivity.kt
+++ b/features/auth/src/main/java/com/techcafe/todone/auth/SignInActivity.kt
@@ -3,9 +3,11 @@ package com.techcafe.todone.auth
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
 import com.techcafe.todone.auth.databinding.ActivitySignInBinding
 
-class SignInActivity : AppCompatActivity() {
+class SignInActivity : AppCompatActivity(R.layout.activity_sign_in) {
 
     private lateinit var binding: ActivitySignInBinding
 
@@ -13,6 +15,5 @@ class SignInActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_sign_in)
-
     }
 }

--- a/features/auth/src/main/java/com/techcafe/todone/auth/signin/SignInFragment.kt
+++ b/features/auth/src/main/java/com/techcafe/todone/auth/signin/SignInFragment.kt
@@ -1,0 +1,65 @@
+package com.techcafe.todone.auth.signin
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.firebase.ui.auth.AuthUI
+import com.firebase.ui.auth.ErrorCodes
+import com.firebase.ui.auth.IdpResponse
+import com.google.firebase.auth.FirebaseAuth
+import com.techcafe.todone.auth.R
+import com.techcafe.todone.auth.databinding.FragmentSignInBinding
+
+/**
+ * A simple [Fragment] subclass.
+ */
+class SignInFragment : Fragment(R.layout.fragment_sign_in) {
+
+    companion object {
+        private const val RC_SIGN_IN = 0
+    }
+
+    private lateinit var binding: FragmentSignInBinding
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentSignInBinding.bind(view)
+
+        val user = FirebaseAuth.getInstance().currentUser
+        if (user != null) {
+            // TODO MainActivityへ遷移
+            binding.textView.text = user.displayName
+        } else {
+            val configs = arrayListOf(
+                AuthUI.IdpConfig.EmailBuilder().build()
+            )
+            val authIntent = AuthUI.getInstance()
+                .createSignInIntentBuilder()
+                .setAvailableProviders(configs)
+                .build()
+            startActivityForResult(authIntent, RC_SIGN_IN)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != RC_SIGN_IN) return
+        val response = IdpResponse.fromResultIntent(data)
+        if (resultCode == Activity.RESULT_OK) {
+            // TODO MainActivityへ遷移
+            Toast.makeText(requireContext(), "Signed in!", Toast.LENGTH_LONG).show()
+            binding.textView.text = "Signed in with " + response?.email
+        } else {
+            val errorMessage = when {
+                response == null -> R.string.sign_in_cancelled
+                response.error?.errorCode == ErrorCodes.NO_NETWORK -> R.string.network_error
+                else -> R.string.unknown_error
+            }
+            Toast.makeText(requireContext(), getString(errorMessage), Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/features/auth/src/main/res/layout/activity_sign_in.xml
+++ b/features/auth/src/main/res/layout/activity_sign_in.xml
@@ -6,13 +6,14 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@android:color/holo_red_dark"
         tools:context=".SignInActivity">
 
         <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/nav_hos_fragment"
+            android:id="@+id/nav_host_fragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:defaultNavHost="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/features/auth/src/main/res/layout/activity_sign_in.xml
+++ b/features/auth/src/main/res/layout/activity_sign_in.xml
@@ -8,12 +8,17 @@
         android:layout_height="match_parent"
         tools:context=".SignInActivity">
 
-        <TextView
-            android:id="@+id/text_view"
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_hos_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:gravity="center"
-            android:text="@string/title_sign_in"
-            android:textSize="32sp" />
+            app:defaultNavHost="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:navGraph="@navigation/navigation_sign_in" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/features/auth/src/main/res/layout/fragment_sign_in.xml
+++ b/features/auth/src/main/res/layout/fragment_sign_in.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/text_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/title_sign_in"
+            android:textSize="32sp" />
+
+    </FrameLayout>
+</layout>

--- a/features/auth/src/main/res/layout/fragment_sign_in.xml
+++ b/features/auth/src/main/res/layout/fragment_sign_in.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -12,7 +13,11 @@
             android:layout_height="match_parent"
             android:gravity="center"
             android:text="@string/title_sign_in"
-            android:textSize="32sp" />
+            android:textSize="32sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## TL;DR

- Mainとは別にSignInに関するnavigation graphの作成とその繋ぎ込み

- Related to #25 

## Why we need this change? (required)
- AuthはMainとは別のフローでnavigationを作りたかったため
- signinやloginのフローは他とは独立している&&バックスタックに無駄に積まずにフローが完了したら全てを閉じたい
  →別Activityに切り出そう
## What does this change? (required)
- authでのnavigationのセッティング
  - SignInActivityにNavHostFragmentを設置。
  - SignInFragmentを作成し、NavHostFragmentで切り替える
## What is the value of this and can you measure success? (required)
- MainからSignInActivity(Fragment)に遷移できる、逆もできる

## How it was implemented

## Where struggled
- 遷移できてるのにSignInFragmentが表示されない...

## Notes

- If you are OK, please approve this PR.
- If anyone approve this PR, I'll merge this PR myself.
