### PR TITLE
Update .gitingnore for hiding google-services.json

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+google-services.json


### PR DESCRIPTION
## TL;DR
`.gitignore`にgoogle-services.jsonを追加

- close null

## Why we need this change? (required)
google-services.jsonがmasterの.gitignoreで設定されてなくて，みんながjsonダウンロードできる状態で間違ってgitの履歴にjsonが含まれないようにするため

## What does this change? (required)
.gitignoreに設定を追加した

## What is the value of this and can you measure success? (required)
`app/.gitignore` を見る

## How it was implemented
ただ追加しただけ

## Where struggled
なし

## Reference links
なし

## Screenshot

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Notes

- If you are OK, please approve this PR.
- If anyone approve this PR, I'll merge this PR myself.
