### PR TITLE
Settings画面とりあえずレイアウトだけ作ったよ

### DIFF
--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation Dep.AndroidX.lifecycleLiveData
     implementation Dep.AndroidX.recyclerView
     implementation Dep.AndroidX.design
+    implementation Dep.AndroidX.preference
 
     implementation Dep.Epoxy.epoxy
     implementation Dep.Epoxy.databindingSupport

--- a/features/settings/src/main/java/com/techcafe/todone/settings/SettingsFragment.kt
+++ b/features/settings/src/main/java/com/techcafe/todone/settings/SettingsFragment.kt
@@ -3,29 +3,17 @@ package com.techcafe.todone.settings
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceFragmentCompat
 import com.techcafe.todone.settings.databinding.FragmentSettingsBinding
 
-class SettingsFragment : Fragment(R.layout.fragment_settings) {
+class SettingsFragment : PreferenceFragmentCompat() {
 
-    lateinit var binding: FragmentSettingsBinding
-    lateinit var controller: SettingController
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences, rootKey)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding = FragmentSettingsBinding.bind(view)
-        binding.lifecycleOwner = viewLifecycleOwner
 
-        controller = SettingController()
-
-        binding.recyclerView.also {
-            it.setController(controller)
-        }
-        val list = listOf(
-            "title" to "message",
-            "タイトル" to "メッセージ",
-            "タイトルだよ" to "メッセージだよ",
-            "あいうえお" to "かきくけこ"
-        )
-        controller.setData(list)
     }
 }

--- a/features/settings/src/main/res/values/arrays.xml
+++ b/features/settings/src/main/res/values/arrays.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <array name="language_labels">
+        <item>日本語</item>
+        <item>English</item>
+    </array>
+    <array name="language_values">
+        <item>JP</item>
+        <item>EN</item>
+    </array>
+</resources>

--- a/features/settings/src/main/res/values/strings.xml
+++ b/features/settings/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
-
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
-
+    <string name="theme_label">Theme</string>
+    <string name="language_label">Language</string>
+    <string name="dark_theme_label">Dark Theme</string>
 </resources>

--- a/features/settings/src/main/res/xml/preferences.xml
+++ b/features/settings/src/main/res/xml/preferences.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory
+        android:key="categoryTheme"
+        android:title="@string/theme_label" >
+        <SwitchPreferenceCompat
+            android:key="dark_theme"
+            android:title="@string/dark_theme_label" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:key="categoryLanguage"
+        android:title="@string/language_label">
+        <ListPreference
+            android:key="language"
+            android:entries="@array/language_labels"
+            app:entryValues="@array/language_values"
+            android:title="@string/language_label"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/features/settings/src/main/res/xml/preferences.xml
+++ b/features/settings/src/main/res/xml/preferences.xml
@@ -5,7 +5,7 @@
         android:key="categoryTheme"
         android:title="@string/theme_label" >
         <SwitchPreferenceCompat
-            android:key="dark_theme"
+            android:key="darkTheme"
             android:title="@string/dark_theme_label" />
     </PreferenceCategory>
     <PreferenceCategory


### PR DESCRIPTION
## TL;DR
とりあえずSettings画面のレイアウトだけ作りました
よってhorisの作ったEpoxyは吹き飛びました

- close #64 

## なんでこの変更が必要だった？ (必須)
ダークテーマの設定と言語設定にアクセスするため

## どんな変更した？ (必須)
上記の設定ができるように，ダークテーマはスイッチで，言語設定はリストから設定できるようにした

## どうやったらこの変更を確認できる？ (必須)
DrawerからSettings選んで遷移してみてね

## どうやって実装した？
PreferenceFragmentCompatとかPreferenceScreenを使っていい感じにやりました

## 苦労したとこ
この辺触ったことなかったからPreferenceScreenで実装できるコンポーネント的なのに何があるのかから調べなきゃいけなかった

## 参考にした記事
- https://medium.com/google-developer-experts/exploring-android-jetpack-preferences-8bcb0b7bdd14
- https://developer.android.com/guide/topics/ui/settings
- https://medium.com/@bhavyakaria/step-by-step-guide-to-create-app-settings-using-preferences-in-android-part-2-9dd3466d1e2
- https://developer.android.com/guide/topics/resources/string-resource

## Screenshot
Settings画面 | Language選択時
:--: | :--:
<img src="https://user-images.githubusercontent.com/28699251/78332783-a5dcb980-75c3-11ea-8ffc-5b06b0bc0fd1.png" width="300" /> | <img src="https://user-images.githubusercontent.com/28699251/78332832-b9882000-75c3-11ea-8aed-9211f701cde5.png" width="300" />

## Notes

- 確認してOKだったらapproveしてね
- 誰かapproveしてくれたらセルフマージするね
