### PR TITLE
Timberの導入

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,38 +6,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
-android {
-    compileSdkVersion Versions.androidCompileSdkVersion
-    buildToolsVersion "29.0.2"
-
-    defaultConfig {
-        applicationId Versions.name
-        minSdkVersion Versions.androidMinSdkVersion
-        targetSdkVersion Versions.androidTargetSdkVersion
-        versionCode 1
-        versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-    }
-    dataBinding {
-        enabled = true
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
+apply from: rootProject.file("gradle/common.gradle")
+android.dataBinding.enabled = true
 dependencies {
     implementation project(':features:home')
     implementation project(':features:notifications')

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-assumenosideeffects class timber.log.Timber {
+    public static *** v(...);
+    public static *** d(...);
+}

--- a/app/src/main/java/com/techcafe/todone/App.kt
+++ b/app/src/main/java/com/techcafe/todone/App.kt
@@ -4,14 +4,26 @@ import android.app.Application
 import com.techcafe.todone.di.moduleList
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
+import timber.log.Timber
 
 class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        initializeKoin()
+        initializeTimber()
+    }
+
+    private fun initializeKoin() {
         startKoin {
             androidContext(this@App)
             modules(modules = moduleList)
+        }
+    }
+
+    private fun initializeTimber() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
         }
     }
 }

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -15,7 +15,7 @@ object Dep {
         val Epoxy = "3.9.0"
         val Coil = "0.9.5"
         val MockK = "1.9.3"
-        val Timber = "5.0.0-SNAPSHOT"
+        val Timber = "4.7.1"
         val Stetho = "1.5.1"
         val DynamicFutureFragment = "2.3.0-SNAPSHOT"
         val LiveData = "2.2.0"
@@ -180,8 +180,6 @@ object Dep {
     }
 
     object Timber {
-        val common = "com.jakewharton.timber:timber-common:${LibsVersion.Timber}"
-        val jdk = "com.jakewharton.timber:timber-jdk:${LibsVersion.Timber}"
-        val android = "com.jakewharton.timber:timber-android:${LibsVersion.Timber}"
+        val timber = "com.jakewharton.timber:timber:${LibsVersion.Timber}"
     }
 }

--- a/features/home/src/main/java/com/techcafe/todone/home/HomeFragment.kt
+++ b/features/home/src/main/java/com/techcafe/todone/home/HomeFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.techcafe.todone.home.databinding.FragmentHomeBinding
+import timber.log.Timber
 
 class HomeFragment : Fragment(R.layout.fragment_home) {
 
@@ -26,6 +27,9 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
 //            "toを初めて知った" to "toを初めて知った",
 //            "データ持ってくる" to "どこからとりあえず取ろう"
 //        )
+
+        // TODO あとで消す
+        Timber.d("$sampleData")
 
         controller.setData(sampleData)
     }

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -1,3 +1,4 @@
+import dependencies.Dep
 import dependencies.Versions
 
 allprojects {
@@ -28,4 +29,7 @@ allprojects {
             }
         }
     }
+}
+dependencies {
+    implementation Dep.Timber.timber
 }


### PR DESCRIPTION
## TL;DR

- close #86

## なんでこの変更が必要だった？ (必須)

Logを簡単に見やすくしてデバッグ効率をあげるため

## どんな変更した？ (必須)

1. `common.gradle` でTimberをimplementationした。
  - そうすると、 `apply from: rootProject.file("gradle/common.gradle")` してるmoduleでTimberが使えるようになる
2. Appクラスで、BuildVariantがDEBUGのときのみTimberのログを出力するように設定する
3. `proguard-rules.pro` で難読化する
   - 難読化する理由は、tokenとか機密情報が抜き取られないようにするため。
   - [参考](https://proandroiddev.com/managing-logging-in-a-multi-module-android-application-eb966fb7fedc)

## どうやったらこの変更を確認できる？ (必須)

HomeFragmentにTimberでログを出すようにしている。
Logcatで、以下の画像のように確認してくだせい
* Log.d(TAG, "hoge")の　TAGは、TImberを書いたクラス名を勝手にTAGにしてくれている
![image](https://user-images.githubusercontent.com/43269230/79035799-b8c33f80-7bfc-11ea-8175-76000ff4eb4c.png)

## 苦労したとこ

## 参考にした記事
https://proandroiddev.com/managing-logging-in-a-multi-module-android-application-eb966fb7fedc


- 確認してOKだったらapproveしてね
- 誰かapproveしてくれたらセルフマージするね
