### PR TITLE
common.gradle に CoroutineとLiveDataの依存関係を追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     testImplementation Dep.Test.junit
     androidTestImplementation Dep.Test.espressoCore
     androidTestImplementation Dep.Test.androidJunit4Ktx
+    implementation Dep.AndroidX.lifecycleLiveData
+    implementation Dep.AndroidX.liveDataCoreKtx
+    implementation Dep.AndroidX.liveDataKtx
     implementation Dep.AndroidX.Navigation.runtimeKtx
     implementation Dep.AndroidX.Navigation.fragmentKtx
     implementation Dep.AndroidX.Navigation.uiKtx

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -90,15 +90,11 @@ object Dep {
     }
 
     object Kotlin {
-
         val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${LibsVersion.Kotlin}"
-
         val coroutines =
             "org.jetbrains.kotlinx:kotlinx-coroutines-core:${LibsVersion.KotlinCoroutines}"
         val androidCoroutinesDispatcher =
             "org.jetbrains.kotlinx:kotlinx-coroutines-android:${LibsVersion.KotlinCoroutines}"
-        val coroutinesReactive =
-            "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${LibsVersion.KotlinCoroutines}"
     }
 
     object Firebase {

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -16,7 +16,5 @@ dependencies {
     implementation Dep.Moshi.moshi
     implementation Dep.Moshi.kotlin
 
-    implementation Dep.Kotlin.stdlib
-    implementation Dep.Kotlin.coroutines
     implementation Dep.Koin.koin
 }

--- a/features/board/build.gradle
+++ b/features/board/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation Dep.AndroidX.design
     implementation Dep.AndroidX.fragmentKtx
     implementation Dep.AndroidX.coreKtx
-    implementation Dep.AndroidX.lifecycleLiveData
     implementation Dep.AndroidX.recyclerView
     implementation Dep.Epoxy.epoxy
     implementation Dep.Epoxy.databindingSupport

--- a/features/profile/build.gradle
+++ b/features/profile/build.gradle
@@ -18,11 +18,8 @@ dependencies {
     implementation Dep.AndroidX.appCompat
     implementation Dep.AndroidX.recyclerView
     implementation Dep.AndroidX.design
-    implementation Dep.AndroidX.liveDataKtx
     implementation Dep.AndroidX.fragmentKtx
-    implementation Dep.AndroidX.lifecycleLiveData
     implementation Dep.AndroidX.activityKtx
-    implementation Dep.AndroidX.liveDataCoreKtx
     // DI
     implementation Dep.Koin.koin
     implementation Dep.Koin.viewModel

--- a/features/settings/build.gradle
+++ b/features/settings/build.gradle
@@ -13,9 +13,6 @@ dependencies {
     implementation Dep.AndroidX.appCompat
     implementation Dep.AndroidX.fragmentKtx
     implementation Dep.AndroidX.coreKtx
-    implementation Dep.AndroidX.liveDataCoreKtx
-    implementation Dep.AndroidX.liveDataKtx
-    implementation Dep.AndroidX.lifecycleLiveData
     implementation Dep.AndroidX.preference
 
     implementation Dep.Koin.koin

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -42,4 +42,9 @@ allprojects {
 }
 dependencies {
     implementation Dep.Timber.timber
+    implementation Dep.Kotlin.coroutines
+    implementation Dep.Kotlin.stdlib
+    implementation Dep.AndroidX.liveDataKtx
+    implementation Dep.AndroidX.liveDataCoreKtx
+    implementation Dep.AndroidX.lifecycleLiveData
 }


### PR DESCRIPTION
## TL;DR

掲題の通り

## なんでこの変更が必要だった？ (必須)

CoroutineとLiveDataはほとんどのモジュールで使用するため。

