### PR TITLE
プロフィールからボードに戻ったときにクラッシュするバグ修正

### DIFF
--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -27,8 +27,8 @@
             android:id="@+id/action_profile_to_edit_profile"
             app:destination="@+id/edit_profile" />
         <action
-            android:id="@+id/action_profile_to_home"
-            app:destination="@id/home" />
+            android:id="@+id/action_profile_to_board"
+            app:destination="@id/board" />
     </fragment>
     <fragment
         android:id="@+id/edit_profile"

--- a/features/profile/src/main/java/com/techcafe/todone/profile/ProfileFragment.kt
+++ b/features/profile/src/main/java/com/techcafe/todone/profile/ProfileFragment.kt
@@ -30,7 +30,7 @@ class ProfileFragment : Fragment() {
         }
 
         binding.backButton.setOnClickListener {
-            findNavController().navigate(R.id.action_profile_to_home)
+            findNavController().navigate(R.id.action_profile_to_board)
         }
     }
 }


### PR DESCRIPTION
## TL;DR

- close #110 

## なんでこの変更が必要だった？ (必須)
アプリがクラッシュするから

## どんな変更した？ (必須)
プロフィールからボードに戻るときのnavigationのactionのid変更とdestination先変更

## どうやったらこの変更を確認できる？ (必須)
プロフィールから左上の戻るボタンで戻る

## どうやって実装した？
id変えただけ

## 苦労したとこ

## 参考にした記事

## Screenshot

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Notes

- 確認してOKだったらapproveしてね
- 誰かapproveしてくれたらセルフマージするね
