### PR TITLE
Results型をもっと簡単に書く

### DIFF
--- a/model/src/main/java/techcafe/todone/Results.kt
+++ b/model/src/main/java/techcafe/todone/Results.kt
@@ -4,4 +4,13 @@ sealed class Results<out T> {
     data class Loading<out T>(val data: T?) : Results<T>()
     data class Success<out T>(val data: T) : Results<T>()
     data class Failure<out T>(val throwable: Throwable) : Results<T>()
+
+    companion object {
+        inline operator fun <T> invoke(block: () -> T): Results<T> =
+            try {
+                Success(block())
+            } catch (e: Throwable) {
+                Failure(e)
+            }
+    }
 }


### PR DESCRIPTION
## TL;DR

- close #143 

## なんでこの変更が必要だった？ (必須)

- 今までは、  
```kotlin
suspend fun getHoge(): Results<Hoge>  =
try {
   Results.Success(service.getHoge())
}catch(e: Throwable) {
   Results.Failure(e)
}
```  
としていたが、  
```kotlin
suspend fun getHoge(): Results<Hoge>  = Results {
   service.getHoge()
}
```

とかけるようにする

## どんな変更した？ (必須)

## どうやったらこの変更を確認できる？ (必須)

## どうやって実装した？

## 苦労したとこ

## 参考にした記事

## Screenshot

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Notes

- 確認してOKだったらapproveしてね
- 誰かapproveしてくれたらセルフマージするね
